### PR TITLE
ers-034 - updated instructions on event page

### DIFF
--- a/eros-web/event_info/event_info.html
+++ b/eros-web/event_info/event_info.html
@@ -19,7 +19,9 @@
     <md-card layout="column" layout-align="center center" style="width: 60%;margin-left:20px;margin-right:20px;padding-top:30px;padding-bottom:30px">
     <md-card-content>
         <p>
-        <b>Time and Location: </b>Your dating event is on {{event.date}} at 7 PM. The event will
+        <b><i>You are ready for the event! Here is some helpful information for you:</b></i>
+        </p>
+        <b>Time and Location: </b>Your dating event is on {{event.date}} at 6:30 PM. The event will
 take place at {{event.name}}, {{event.location}}.</p>
 
 <p>
@@ -28,12 +30,13 @@ computer that is provided to you at the event) and then engage
 in "speed dates" with other daters at the event.</p>
 
 <p>
-<b>Refund: </b> As a reminder, you will receive $20 to spend on drinks/food at the bar when you arrive. You will also be refunded the Eventbrite registration fee when you arrive at the event.
+<b>Drinks: </b> You will receive $20 to spend on drinks/food at the bar when you arrive.
 </p>
 
 <b>Contact: </b> Contact the event organizer with any questions - Doug Zytko, daz2@njit.edu.
 </p>
 
+(Ignore the buttons below this line. They are supposed to be grayed out.)
 
 
 

--- a/eros-web/event_info/event_info.html
+++ b/eros-web/event_info/event_info.html
@@ -36,7 +36,7 @@ in "speed dates" with other daters at the event.</p>
 <b>Contact: </b> Contact the event organizer with any questions - Doug Zytko, daz2@njit.edu.
 </p>
 
-(Ignore the buttons below this line. They are supposed to be grayed out.)
+<p>(Ignore the buttons below this line. They are supposed to be grayed out.)</p>
 
 
 


### PR DESCRIPTION
Updated instructions so the user isn't confused as to why the evaluation buttons are grayed out. Also modifed the event info.